### PR TITLE
grandppltedx: overlay: Define dual sim slot counts

### DIFF
--- a/overlay/frameworks/base/core/res/res/values/config.xml
+++ b/overlay/frameworks/base/core/res/res/values/config.xml
@@ -236,5 +236,12 @@
          timeout expires.  May be less than the minimum allowed brightness setting
          that can be set by the user. -->
     <integer name="config_screenBrightnessDim">5</integer>
+     
+     <!-- Number of physical SIM slots on the device. This includes both eSIM and pSIM slots, and
+         is not necessarily the same as the number of phones/logical modems supported by the device.
+         For example, a multi-sim device can have 2 phones/logical modems, but 3 physical slots,
+         or a single SIM device can have 1 phones/logical modems, but 2 physical slots (one eSIM
+         and one pSIM) -->
+    <add-resource type="integer" name="config_num_physical_slots">2</add-resource>
 
 </resources>


### PR DESCRIPTION
Logs :
Unexpected error getting slot status: com.android.internal.telephony.CommandException: RADIO_NOT_AVAILABLE

from logs:
RilRequest: [3656]< RIL_REQUEST_CDMA_SET_SUBSCRIPTION_SOURCE error: com.android.internal.telephony.CommandException: RADIO_NOT_AVAILABLE ret=